### PR TITLE
管理者側レシピランキングいいね色修正

### DIFF
--- a/app/views/public/recipes/index.html.erb
+++ b/app/views/public/recipes/index.html.erb
@@ -58,7 +58,7 @@
                     <li><%=link_to recipe.user.name, admin_user_path(recipe.user), class:"user-name-link" %></li>
                     <li><%=link_to recipe.title, admin_recipe_path(recipe), class:"recipe-title recipe-title-link" %></li>
                     <li class="mt-1"><%= render "admin/recipes/recipe_tag", recipe_tags: recipe.tags %></li>
-                    <li>♥<%= recipe.favorites.count %>件/ <i class="fa-regular fa-comment"></i> <%= recipe.comments.count %>件</li>
+                    <li><span class="favorite-btn-red">♥</span><%= recipe.favorites.count %>件/ <i class="fa-regular fa-comment"></i> <%= recipe.comments.count %>件</li>
                   <ul>
                 </div>
               </div>


### PR DESCRIPTION
## 管理者側のレシピランキングページ修正
* いいねのハートマークの色が黒になっていたため、赤に修正